### PR TITLE
add support for meteor 0.8.3

### DIFF
--- a/lib/inline-help.js
+++ b/lib/inline-help.js
@@ -5,7 +5,7 @@ InlineHelp = function() {};
 Handlebars.registerHelper( "showHelp", function( key ){
   if ( Package && Package.UI )
     return Template.showHelp;
-  else 
+  else
     return new Handlebars.SafeString( Template.showHelp( key ) );
 });
 
@@ -35,7 +35,7 @@ Template.showHelp.helpers({
   }
 });
 
-Template._helpPopover.urlForMessage = function(){ 
+Template._helpPopover.urlForMessage = function(){
   return this.url && new Handlebars.SafeString( "<a href='" + this.url + "' class='' target='_blank'>Read More</a>");
 };
 
@@ -45,8 +45,7 @@ InlineHelp.showHelp = function(helpKey, insideHandlebars) {
     data.key = helpKey;
     data.directCall = !insideHandlebars;
     if(data.directCall){
-      var html = UI.toHTML(Template._helpPopover.extend({data: function () { return data; }}));
-      return html;
+      return templateToHtml(Template._helpPopover, data);
     }
     return data;
   }else {
@@ -54,3 +53,16 @@ InlineHelp.showHelp = function(helpKey, insideHandlebars) {
   }
 }
 
+function templateToHtml(template, data) {
+  if(UI.toHTML) {
+    // for Meteor < 0.8.3
+    return UI.toHTML(template.extend({data: function () {
+      return data;
+    }}));
+  } else {
+    // for Meteor 0.8.3 =>
+    return Blaze.toHTML(Blaze.With(data, function() {
+      return template;
+    }));
+  }
+}


### PR DESCRIPTION
problem was with the new blaze API changes comes with meteor 0.8.3
I need to rewrite the template to html functionality. 

But I've added backward compatibility as well with previous versions.
